### PR TITLE
Add NPM publish workflow for release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,7 @@
 name: CI
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+concurrency:
+  group: ${{ github.workflow }}
 
 jobs:
   typecheck:
@@ -22,8 +19,10 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version: '1.24'
-    - run: pnpm install --frozen-lockfile
-    - run: pnpm typecheck
+    - run: |
+        pnpm install --frozen-lockfile
+        pnpm typecheck
+      shell: bash
     
   test:
     runs-on: ubuntu-latest
@@ -40,6 +39,16 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version: '1.24'
-    - run: pnpm install --frozen-lockfile
-    - run: pnpm build
-    - run: pnpm test
+    - run: |
+        pnpm install --frozen-lockfile
+        pnpm build
+        pnpm test
+      shell: bash
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,52 @@
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  check-version:
+    # Only run if the CI workflow succeeded
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      is-new-version: ${{ steps.check.outputs.is-new-version }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: PostHog/check-package-version@v2    
+
+  pnpm-publish:
+    needs: check-version
+    # Don't bother publishing if the package version hasn't gone up
+    if: needs.check-version.outputs.is-new-version == 'true'
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: pnpm
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+      - run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+          pnpm install --frozen-lockfile
+          pnpm build
+          pnpm publish --no-git-checks --access public
+        shell: bash
+
+name: Release
+
+on:
+  workflow_run:
+    # Only do the release workflow if CI on master passes cleanly
+    workflows: ["CI"]
+    types:
+      - completed
+    branches:
+      - master
+
+permissions:
+  id-token: write


### PR DESCRIPTION
Added the GitHub Actions workflow to allow publishing this whenever the `package.json` version gets updated and landed on `master`.

@tarasglek this is going to require you to add an `NPM_TOKEN` to the GitHub Actions secrets, with sufficient rights to publish this package.

Are we cool with `eget.wasm` as the package name?  I wonder if it should be `eget-wasm` to match convention (e.g., https://www.npmjs.com/package/napi-wasm).